### PR TITLE
Sets charset to utf-8 in content-type when posting Sparql.

### DIFF
--- a/lib/rialto/etl/writers/sparql_writer.rb
+++ b/lib/rialto/etl/writers/sparql_writer.rb
@@ -132,7 +132,7 @@ module Rialto
         def connection_headers
           {
             'X-Api-Key' => Settings.sparql_writer.api_key,
-            'Content-Type' => 'application/sparql-update'
+            'Content-Type' => 'application/sparql-update; charset=utf-8'
           }
         end
       end


### PR DESCRIPTION
refs https://github.com/sul-dlss/rialto-webapp/issues/148