### PR TITLE
Add GeoNames mappings for "Unmapped country" output

### DIFF
--- a/lib/translation_maps/additional_country_names_to_geocode_ids.yaml
+++ b/lib/translation_maps/additional_country_names_to_geocode_ids.yaml
@@ -1,8 +1,18 @@
-england: 2635167
-mongol peo rep: 2029969
-peoples r china: 1814991
-scotland: 2635167
-wales: 2635167
-papua n guinea: 2088628
+anguilla: 2635167
+bermuda: 2635167
 cote ivoire: 2287781
+dem rep congo: 203312
+england: 2635167
+micronesia: 2081918
+mongol peo rep: 2029969
+neth antilles: 8505032
+new caledonia: 3017382
+north ireland: 2635167
+palestine: 6254930
+palestinian ter: 6254930
+papua n guinea: 2088628
+peoples r china: 1814991
+rep of georgia: 614540
+scotland: 2635167
 u arab emirates: 290557
+wales: 2635167


### PR DESCRIPTION
Note the following:

* Micronesia is mapped to the Federated States of Micronesia
* Neth Antilles is mapped onto the dissolved (as of 2010) country of Netherland Antilles
* New Caledonia is mapped to France
* Both Palestine-related strings are mapped to the semi-independent political entity of Palestine (not to a country, *per se*)

And I sorted the file.