### PR TITLE
Don't use processing threads for sparql load

### DIFF
--- a/lib/rialto/etl/configs/sparql.rb
+++ b/lib/rialto/etl/configs/sparql.rb
@@ -8,4 +8,5 @@ settings do
   provide 'sparql_writer.update_url', ::Settings.sparql_writer.update_url
   provide 'sparql_writer.thread_pool', 0
   provide 'sparql_writer.batch_size', ::Settings.sparql_writer.batch_size
+  provide 'processing_thread_pool', 0 # Turns off multithreading, for debugging
 end


### PR DESCRIPTION
Using threads causes Neptune to raise ConcurrentModificationExceptions