### PR TITLE
Update ETL logging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,14 @@ Metrics/BlockLength:
     - spec/**/*.rb
     - rialto-etl.gemspec
 
+RSpec/AnyInstance:
+  Exclude:
+  - spec/extractors/stanford_organizations_spec.rb
+  - spec/extractors/stanford_researchers_spec.rb
+  - spec/readers/ndjson_reader_spec.rb
+  - spec/readers/sparql_statement_reader_spec.rb
+  - spec/transformers/people_spec.rb
+  - spec/writers/sparql_writer_spec.rb
 
 RSpec/ExampleLength:
   Enabled: false

--- a/lib/rialto/etl/cli/load.rb
+++ b/lib/rialto/etl/cli/load.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'rialto/etl/loaders'
+require 'rialto/etl/logging'
 
 module Rialto
   module Etl
     module CLI
       # Load subcommand
       class Load < Thor
+        include Rialto::Etl::Logging
+
         option :input_file,
                required: true,
                banner: 'FILENAME',

--- a/lib/rialto/etl/configs/sparql.rb
+++ b/lib/rialto/etl/configs/sparql.rb
@@ -2,6 +2,7 @@
 
 require 'rialto/etl/readers/sparql_statement_reader'
 require 'rialto/etl/writers/sparql_writer'
+require 'rialto/etl/logging'
 
 extend Rialto::Etl::Logging
 

--- a/lib/rialto/etl/configs/sparql.rb
+++ b/lib/rialto/etl/configs/sparql.rb
@@ -2,6 +2,11 @@
 
 require 'rialto/etl/readers/sparql_statement_reader'
 require 'rialto/etl/writers/sparql_writer'
+
+extend Rialto::Etl::Logging
+
+self.logger = logger
+
 settings do
   provide 'writer_class_name', 'Rialto::Etl::Writers::SparqlWriter'
   provide 'reader_class_name', 'Rialto::Etl::Readers::SparqlStatementReader'

--- a/lib/rialto/etl/configs/stanford_organizations_to_sparql_statements.rb
+++ b/lib/rialto/etl/configs/stanford_organizations_to_sparql_statements.rb
@@ -9,6 +9,7 @@ extend TrajectPlus::Macros
 extend TrajectPlus::Macros::JSON
 extend Rialto::Etl::NamedGraphs
 extend Rialto::Etl::Vocabs
+extend Rialto::Etl::Logging
 
 ORGS_NEEDING_CONTEXT = ['External Relations',
                         'Administration',
@@ -23,6 +24,8 @@ def contextualized_org_name(organization)
   end
   organization['name']
 end
+
+self.logger = logger
 
 settings do
   provide 'writer_class_name', 'Rialto::Etl::Writers::SparqlStatementWriter'

--- a/lib/rialto/etl/extractors/sera.rb
+++ b/lib/rialto/etl/extractors/sera.rb
@@ -47,7 +47,7 @@ module Rialto
             hash['SeRARecord']
           end
         rescue StandardError => exception
-          logger.warn "Error in extracting from SERA. #{exception.message} (#{exception.class})"
+          logger.error "Error in extracting from SERA. #{exception.message} (#{exception.class})"
           raise
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/rialto/etl/extractors/stanford_researchers.rb
+++ b/lib/rialto/etl/extractors/stanford_researchers.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 require 'ruby-progressbar'
+require 'rialto/etl/logging'
 
 module Rialto
   module Etl
     module Extractors
       # Stanford Profiles API
       class StanfordResearchers
+        include Rialto::Etl::Logging
+
         def initialize(client: ServiceClient::StanfordClient.new, per_page: 100, start_page: 1)
           @client = client
           @per_page = per_page # 100 seems to be the max the API allows
@@ -26,7 +29,7 @@ module Rialto
             end
           end
         rescue StandardError => exception
-          warn "Error: #{exception.message}"
+          logger.error "Error: #{exception.message}"
         end
 
         attr_reader :total_pages

--- a/lib/rialto/etl/logging.rb
+++ b/lib/rialto/etl/logging.rb
@@ -10,7 +10,7 @@ module Rialto
       attr_writer :logger
 
       def logger
-        @logger ||= Yell::Logger.new do |logger|
+        @logger ||= Yell.new do |logger|
           logger.adapter :datefile, 'rialto_etl.log', level: 'lte.warn' # anything lower or equal to :warn
           logger.adapter :datefile, 'rialto_etl_error.log', level: 'gte.error' # anything greater or equal to :error
         end

--- a/lib/rialto/etl/logging.rb
+++ b/lib/rialto/etl/logging.rb
@@ -10,11 +10,9 @@ module Rialto
       attr_writer :logger
 
       def logger
-        @logger ||= Yell::Logger.new(:null).tap do |logger|
-          # Everything to stderr
-          logger.adapter :stderr
-          # Warnings to file
-          logger.adapter :datefile, 'warnings.log', level: [:warn]
+        @logger ||= Yell::Logger.new do |logger|
+          logger.adapter :datefile, 'rialto_etl.log', level: 'lte.warn' # anything lower or equal to :warn
+          logger.adapter :datefile, 'rialto_etl_error.log', level: 'gte.error' # anything greater or equal to :error
         end
       end
     end

--- a/lib/rialto/etl/readers/ndjson_reader.rb
+++ b/lib/rialto/etl/readers/ndjson_reader.rb
@@ -16,10 +16,6 @@ module Rialto
           @input_stream = input_stream
         end
 
-        # def logger
-        #   @logger ||= (@settings[:logger] || Yell.new(STDERR, level: 'gt.fatal')) # null logger)
-        # end
-
         def each
           return enum_for(:each) unless block_given?
 

--- a/lib/rialto/etl/readers/ndjson_reader.rb
+++ b/lib/rialto/etl/readers/ndjson_reader.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rialto/etl/logging'
+
 module Rialto
   module Etl
     module Readers
@@ -7,15 +9,16 @@ module Rialto
       # UTF-8 encoding is required.
       class NDJsonReader
         include Enumerable
+        include Rialto::Etl::Logging
 
         def initialize(input_stream, settings)
           @settings = settings
           @input_stream = input_stream
         end
 
-        def logger
-          @logger ||= (@settings[:logger] || Yell.new(STDERR, level: 'gt.fatal')) # null logger)
-        end
+        # def logger
+        #   @logger ||= (@settings[:logger] || Yell.new(STDERR, level: 'gt.fatal')) # null logger)
+        # end
 
         def each
           return enum_for(:each) unless block_given?

--- a/lib/rialto/etl/readers/sparql_statement_reader.rb
+++ b/lib/rialto/etl/readers/sparql_statement_reader.rb
@@ -3,6 +3,7 @@
 require 'yell'
 require 'active_support'
 require 'active_support/core_ext/numeric/conversions'
+require 'rialto/etl/logging'
 
 module Rialto
   module Etl
@@ -13,6 +14,7 @@ module Rialto
       # UTF-8 encoding is required.
       class SparqlStatementReader
         include Enumerable
+        include Rialto::Etl::Logging
 
         attr_reader :settings, :input_stream
         attr_accessor :insert_count
@@ -21,11 +23,6 @@ module Rialto
           @settings = settings
           @input_stream = input_stream
           @insert_count = 0
-        end
-
-        # Get the logger from the settings, or default to an effectively null logger
-        def logger
-          settings['logger'] ||= Yell.new(STDERR, level: 'gt.fatal') # null logger
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/lib/rialto/etl/service_client/entity_resolver.rb
+++ b/lib/rialto/etl/service_client/entity_resolver.rb
@@ -40,7 +40,7 @@ module Rialto
             raise "Entity resolver returned #{resp.status} for #{type} type and #{params} params."
           end
         rescue StandardError => exception
-          logger.warn "Error resolving with path #{path}: #{exception.message}"
+          logger.error "Error resolving with path #{path}: #{exception.message}"
           raise
         end
         # rubocop:enable Metrics/MethodLength

--- a/lib/rialto/etl/service_client/web_of_science_client.rb
+++ b/lib/rialto/etl/service_client/web_of_science_client.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require 'rialto/etl/logging'
+
 module Rialto
   module Etl
     module ServiceClient
       # Client for hitting Stanford APIs using Stanford authz
       class WebOfScienceClient
+        include Rialto::Etl::Logging
+
         HOST = 'api.clarivate.com'
         USER_QUERY_PATH = '/api/wos'
         USER_QUERY_PARAMS = { 'databaseId' => 'WOS' }.freeze
@@ -59,7 +63,7 @@ module Rialto
           raise "#{response.reason_phrase}: #{response.status}  (#{response.body})" unless response.success?
           JSON.parse(response.body)
         rescue StandardError => exception
-          logger.warn "Error fetching #{path}: #{exception.message} (#{exception.class})"
+          logger.error "Error fetching #{path}: #{exception.message} (#{exception.class})"
           raise
         end
 
@@ -101,10 +105,6 @@ module Rialto
           {
             'X-ApiKey' => Settings.wos.api_key
           }
-        end
-
-        def logger
-          @logger ||= Yell.new(STDERR)
         end
       end
     end

--- a/lib/rialto/etl/writers/sparql_writer.rb
+++ b/lib/rialto/etl/writers/sparql_writer.rb
@@ -8,6 +8,7 @@ require 'traject/thread_pool'
 
 require 'concurrent' # for atomic_fixnum
 require 'rialto/etl/service_client/retriable_connection_factory'
+require 'rialto/etl/logging'
 
 module Rialto
   module Etl
@@ -30,6 +31,7 @@ module Rialto
       #   or mock object to be used for SPARQL.
       class SparqlWriter
         include Traject::QualifiedConstGet
+        include Rialto::Etl::Logging
 
         DEFAULT_BATCH_SIZE = 100
 
@@ -107,13 +109,8 @@ module Rialto
           end
           raise ErrorResponse, "#{response.reason_phrase}: #{response.status}  (#{response.body})" unless response.success?
         rescue StandardError => exception
-          logger.warn "Error in SPARQL update. #{exception.message} (#{exception.class})"
+          logger.error "Error in SPARQL update. #{exception.message} (#{exception.class})"
           raise
-        end
-
-        # Get the logger from the settings, or default to an effectively null logger
-        def logger
-          settings['logger'] ||= Yell.new(STDERR, level: 'gt.fatal') # null logger
         end
 
         # How many threads to use for the writer?

--- a/spec/extractors/stanford_organizations_spec.rb
+++ b/spec/extractors/stanford_organizations_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Rialto::Etl::Extractors::StanfordOrganizations do
       }.to_json
     end
 
+    let(:logger) { instance_double('Yell::Logger') }
+
     before do
       stub_request(:get, /authz.stanford.edu/)
         .to_return(status: 200, body: authz_json, headers: {})
@@ -29,10 +31,13 @@ RSpec.describe Rialto::Etl::Extractors::StanfordOrganizations do
 
       before do
         allow(extractor).to receive(:client).and_raise(error_message)
+        allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error)
       end
 
       it 'prints out the exception' do
-        expect { extractor.each {} }.to output(/Uh oh!/).to_stderr
+        extractor.each {}
+        expect(logger).to have_received(:error)
       end
     end
   end

--- a/spec/extractors/stanford_researchers_spec.rb
+++ b/spec/extractors/stanford_researchers_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Rialto::Etl::Extractors::StanfordResearchers do
       }.to_json
     end
 
+    let(:logger) { instance_double('Yell::Logger') }
+
     before do
       stub_request(:get, /authz.stanford.edu/)
         .to_return(status: 200, body: authz_json, headers: {})
@@ -25,10 +27,13 @@ RSpec.describe Rialto::Etl::Extractors::StanfordResearchers do
 
       before do
         allow(extractor).to receive(:client).and_raise(error_message)
+        allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error)
       end
 
       it 'prints out the exception' do
-        expect { extractor.each {} }.to output("Error: #{error_message}\n").to_stderr
+        extractor.each {}
+        expect(logger).to have_received(:error)
       end
     end
 

--- a/spec/readers/ndjson_reader_spec.rb
+++ b/spec/readers/ndjson_reader_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe Rialto::Etl::Readers::NDJsonReader do
   let(:reader) { File.open('spec/fixtures/organizations.ndj', 'r') }
   let(:settings) { {} }
 
+  let(:logger) { instance_double('Yell::Logger') }
+
   describe '#each' do
     it 'calls each once for each line in the file' do
       count = 0
@@ -33,13 +35,10 @@ RSpec.describe Rialto::Etl::Readers::NDJsonReader do
     it { is_expected.to be_kind_of Hash }
 
     context 'when an error occurs' do
-      # rubocop:disable RSpec/VerifiedDoubles
-      let(:logger) { double(Yell) }
-      # rubocop:enable RSpec/VerifiedDoubles
       let(:row) { '{' }
 
       before do
-        allow(Yell).to receive(:new).and_return(logger)
+        allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
         allow(logger).to receive(:error)
       end
 

--- a/spec/readers/sparql_statement_reader_spec.rb
+++ b/spec/readers/sparql_statement_reader_spec.rb
@@ -3,35 +3,29 @@
 require 'rialto/etl/readers/sparql_statement_reader'
 
 RSpec.describe Rialto::Etl::Readers::SparqlStatementReader do
-  let(:reader) { described_class.new('', settings) }
+  let(:reader) { described_class.new('', '') }
 
   describe '#logger' do
-    let(:logger) { double }
+    let(:logger) { instance_double('Yell::Logger') }
     let(:message) { 'Did a thing!' }
 
     before do
+      allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
       allow(logger).to receive(:info)
     end
 
     context 'when specified in settings' do
-      let(:settings) { { 'logger' => logger } }
-
       it 'uses the given logger' do
         reader.logger.info(message)
-        expect(logger).to have_received(:info).with(message)
+        expect(logger).to have_received(:info)
       end
     end
 
     context 'when not specified in settings' do
       let(:settings) { {} }
 
-      before do
-        allow(Yell).to receive(:new).and_return(logger)
-      end
-
       it 'uses a null logger' do
         reader.logger.info(message)
-        expect(Yell).to have_received(:new)
         expect(logger).to have_received(:info).with(message)
       end
     end

--- a/spec/service_client/entity_resolver_spec.rb
+++ b/spec/service_client/entity_resolver_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Rialto::Etl::ServiceClient::EntityResolver do
     # Makes sure Entity Resolver is using above settings.
     described_class.instance.initialize_connection
     described_class.instance.logger = logger
-    allow(logger).to receive(:warn)
+    allow(logger).to receive(:error)
   end
 
   describe '.resolve' do
@@ -43,7 +43,7 @@ RSpec.describe Rialto::Etl::ServiceClient::EntityResolver do
       end
       it 'raises error' do
         expect { resolve }.to raise_error(RuntimeError)
-        expect(logger).to have_received(:warn).with('Error resolving with path person?' \
+        expect(logger).to have_received(:error).with('Error resolving with path person?' \
           'orcid_id=0000-0002-2328-2018&full_name=Wilson%2C+Jennifer+L.: Entity resolver returned 500 for person type ' \
           'and {"orcid_id"=>"0000-0002-2328-2018", "full_name"=>"Wilson, Jennifer L."} params.')
       end

--- a/spec/transformers/people_spec.rb
+++ b/spec/transformers/people_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Rialto::Etl::Transformers::People do
     subject(:positions) { described_class.construct_stanford_positions(titles: titles, profile_id: id) }
 
     let(:id) { '123' }
+    let(:logger) { instance_double('Yell::Logger') }
+
+    before do
+      allow_any_instance_of(Rialto::Etl::Transformers::People::Positions).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:warn)
+    end
 
     context 'when titles are present' do
       let(:titles) do
@@ -49,7 +55,8 @@ RSpec.describe Rialto::Etl::Transformers::People do
         expect(positions).to eq []
       end
       it 'logs a warning' do
-        expect { positions.each {} }.to output(/has no Stanford positions because no titles/).to_stderr
+        positions.each {}
+        expect(logger).to have_received(:warn)
       end
     end
 
@@ -77,7 +84,8 @@ RSpec.describe Rialto::Etl::Transformers::People do
       end
 
       it 'logs a warning for organization' do
-        expect { positions.each {} }.to output(/Unmapped organization/).to_stderr
+        positions.each {}
+        expect(logger).to have_received(:warn)
       end
 
       it 'adds a dummy department' do

--- a/spec/writers/sparql_writer_spec.rb
+++ b/spec/writers/sparql_writer_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Rialto::Etl::Writers::SparqlWriter do
     described_class.new(
       'sparql_writer.update_url' => 'http://127.0.0.1:9999/sparql',
       'sparql_writer.thread_pool' => 0,
-      'sparql_writer.batch_size' => batch_size,
-      'logger': logger
+      'sparql_writer.batch_size' => batch_size
     )
   end
 
@@ -24,7 +23,8 @@ RSpec.describe Rialto::Etl::Writers::SparqlWriter do
   let(:status) { 200 }
 
   before do
-    allow(logger).to receive(:warn)
+    allow_any_instance_of(described_class).to receive(:logger).and_return(logger)
+    allow(logger).to receive(:error)
     allow(logger).to receive(:info)
     allow(logger).to receive(:debug)
 
@@ -49,7 +49,7 @@ RSpec.describe Rialto::Etl::Writers::SparqlWriter do
 
       it 'raises an error' do
         expect { writer.put(batch) }.to raise_error(Rialto::Etl::ErrorResponse)
-        expect(logger).to have_received(:warn).with('Error in SPARQL update. : 500  () (Rialto::Etl::ErrorResponse)')
+        expect(logger).to have_received(:error).with('Error in SPARQL update. : 500  () (Rialto::Etl::ErrorResponse)')
       end
     end
   end


### PR DESCRIPTION
Update the ETL logging to allow the cloudwatch agent to track a file and upload to cloudwatch.