### PR TITLE
Fix untested extractor invocation bug

### DIFF
--- a/lib/rialto/etl/cli/extract.rb
+++ b/lib/rialto/etl/cli/extract.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/keys'
 require 'rialto/etl/extractors'
 
 module Rialto
@@ -42,7 +43,7 @@ module Rialto
         private
 
         def extractor(name)
-          Rialto::Etl::Extractors.const_get(name).new(options)
+          Rialto::Etl::Extractors.const_get(name).new(options.symbolize_keys)
         end
       end
     end

--- a/lib/rialto/etl/extractors/sera.rb
+++ b/lib/rialto/etl/extractors/sera.rb
@@ -11,8 +11,8 @@ module Rialto
       class Sera
         include Rialto::Etl::Logging
 
-        def initialize(options = {})
-          @sunetid = options.fetch(:sunetid)
+        def initialize(sunetid:)
+          @sunetid = sunetid
         end
 
         # Hit an API endpoint and return the results

--- a/lib/rialto/etl/extractors/web_of_science.rb
+++ b/lib/rialto/etl/extractors/web_of_science.rb
@@ -9,15 +9,16 @@ module Rialto
       class WebOfScience
         DEFAULT_INSTITUTION = 'Stanford University'
 
-        attr_reader :client
+        attr_reader :client, :institution, :since
 
-        # @param [Hash] options
-        # @option options [String] :client a preconfigured client.  May be used for testing, all other
-        #                                  options will be ignored.
-        # @option options [String] :institution ('Stanford University') The institution to search for
-        # @option options [String] :since (nil) How far back to retrieve records. If not provided, extract all records.
-        def initialize(**options)
-          @client = options.fetch(:client) { build_client(options) }
+        # @param client [String] a preconfigured client. May be used for testing, all other options will be ignored.
+        # @param institution [String] The institution to search for (default: 'Stanford University')
+        # @param since [String] How far back to retrieve records. If not provided, extract all records. (default: nil)
+        def initialize(client: nil, institution: DEFAULT_INSTITUTION, since: nil)
+          @institution = institution
+          @since = since
+          # Must appear after other ivars because `#build_client` depends on the `#institution` and `#since` getters
+          @client = client || build_client
         end
 
         # Use the client to iterate over records and yield them as JSON
@@ -30,10 +31,10 @@ module Rialto
 
         private
 
-        def build_client(options)
+        def build_client
           ServiceClient::WebOfScienceClient.new(
-            institution: options.fetch(:institution, DEFAULT_INSTITUTION),
-            since: options[:since]
+            institution: institution,
+            since: since
           )
         end
       end

--- a/spec/cli/extract_spec.rb
+++ b/spec/cli/extract_spec.rb
@@ -1,7 +1,36 @@
 # frozen_string_literal: true
 
 RSpec.describe Rialto::Etl::CLI::Extract do
-  subject(:extractor) { described_class.new }
+  subject(:extractor) { described_class.new([], args, conf) }
+
+  let(:args) do
+    []
+  end
+
+  let(:command) { described_class.all_commands['call'] }
+
+  let(:conf) do
+    {
+      current_command: command,
+      command_options: command.options
+    }
+  end
+
+  describe 'integration test' do
+    let(:args) do
+      ['--since', '1D']
+    end
+
+    before do
+      stub_request(:get, 'https://api.clarivate.com/api/wos?count=1&databaseId=WOS&firstRecord=1&loadTimeSpan=1D&usrQuery=OG=Stanford%20University')
+        .to_return(status: 200, body: '{}', headers: {})
+    end
+
+    it 'passes options that do not cause the extractor to raise' do
+      extractor.invoke_command(command, 'WebOfScience')
+      expect { extractor.invoke_command(command, 'WebOfScience') }.not_to raise_error
+    end
+  end
 
   # rubocop:disable RSpec/VerifiedDoubles
   describe '#call' do
@@ -14,28 +43,40 @@ RSpec.describe Rialto::Etl::CLI::Extract do
       allow(Rialto::Etl::Extractors).to receive(:const_get).with(extractor_name).and_return(mock_extractor_class)
     end
 
-    it 'raises ArgumentError when called without args' do
-      expect { extractor.call }.to raise_error(ArgumentError)
+    context 'when called without args' do
+      let(:args) do
+        []
+      end
+
+      it 'raises an exception' do
+        expect { extractor.invoke_command(command) }.to raise_error(Thor::InvocationError)
+      end
     end
-    it 'calls an extractor' do
-      allow(extractor).to receive(:say).with(result)
-      allow(mock_extractor_instance).to receive(:each).and_yield(result)
-      extractor.call(extractor_name)
-      expect(mock_extractor_instance).to have_received(:each).once
-      expect(extractor).to have_received(:say).once
+
+    context 'when called with an extractor name arg' do
+      it 'calls the named extractor' do
+        allow(extractor).to receive(:say).with(result)
+        allow(mock_extractor_instance).to receive(:each).and_yield(result)
+        extractor.invoke_command(command, extractor_name)
+        expect(mock_extractor_instance).to have_received(:each).once
+        expect(extractor).to have_received(:say).once
+      end
     end
   end
   # rubocop:enable RSpec/VerifiedDoubles
 
   describe '#list' do
+    let(:command) { described_class.all_commands['list'] }
+
     it 'prints out callable extractors' do
       allow(extractor).to receive(:say)
-      extractor.list
+      extractor.invoke_command(command)
       expect(extractor).to have_received(:say).with(/StanfordOrganizations, StanfordResearchers/)
     end
+
     it 'omits non-callable extractors' do
       allow(extractor).to receive(:say)
-      extractor.list
+      extractor.invoke_command(command)
       expect(extractor).not_to have_received(:say).with(/Abstract/)
     end
   end


### PR DESCRIPTION
The Extract CLI previously passed the set of Thor options (a Hash) to the Extractor class. This worked fine for some extractors but not for `WebOfScience`, whose `#initialize` method takes only the `**options` arg (as of https://github.com/sul-dlss/rialto-etl/commit/a4bd281785feda997e8dc7e96bd742ff89aff6d1#diff-738314c70d310a856fcb90452b4f8932R18). Thus if you were to invoke the Extract CLI for WoS with any options (e.g., `--since` or `--institution`), you would see `ArgumentError: wrong number of arguments (given 1, expected 0)`. This commit also makes the other extractor classes conform to the same API for `#initialize`.