### PR TITLE
Use the logger for honeybadger

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,7 @@ set :output, 'log/etl_cron.log'
 
 job_type :exe, 'cd :path && :task'
 
-every :tuesday, at: '01:05pm' do
+every :tuesday, at: '01:45pm' do
   exe 'exe/extract call StanfordOrganizations > data/organizations.json ' \
     '&& exe/transform call StanfordOrganizations -i data/organizations.json > data/organizations.sparql ' \
     '&& exe/load call Sparql -i data/organizations.sparql ' \

--- a/lib/rialto/etl/cli/error_reporter.rb
+++ b/lib/rialto/etl/cli/error_reporter.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
-require 'honeybadger'
+require 'honeybadger/ruby'
 
 module Rialto
   module Etl
     module CLI
       # Logs errors to STDERR and to Honeybadger
       class ErrorReporter
+        extend Logging
+
+        # Set up Honeybadger manually, so that we set the logger before honeybadger
+        # logs its first message.
+        Honeybadger.init!(framework: :ruby, env: ENV['RUBY_ENV'])
+        Honeybadger.load_plugins!
+        Honeybadger.install_at_exit_callback
+        Honeybadger.configure do |config|
+          config.logger = logger
+        end
+
         # rubocop:disable Style/StderrPuts
         def self.log_exception(message)
           $stderr.puts message
+
           Honeybadger.notify(message)
         end
         # rubocop:enable Style/StderrPuts


### PR DESCRIPTION
This prevents the honeybadger log messages being redirected into the json produced by the extractor