### PR TITLE
Ignore blank sunet when querying SERA

### DIFF
--- a/lib/rialto/etl/cli/grants.rb
+++ b/lib/rialto/etl/cli/grants.rb
@@ -97,6 +97,7 @@ module Rialto
           end
           # Don't write file if an exception occurs
           begin
+            return extract_file if row[:sunetid].empty? # return from extract without calling SERA API
             results = perform_extract(row)
           rescue StandardError => exception
             log_exception "Skipping #{extract_file} because an error occurred while extracting: " \

--- a/lib/rialto/etl/cli/grants.rb
+++ b/lib/rialto/etl/cli/grants.rb
@@ -98,7 +98,7 @@ module Rialto
           # Don't write file if an exception occurs
           begin
             return extract_file if row[:sunetid].empty? # return from extract without calling SERA API
-            results = perform_extract(row)
+            results = perform_extract(row[:sunetid])
           rescue StandardError => exception
             log_exception "Skipping #{extract_file} because an error occurred while extracting: " \
                           "#{exception.message} (#{exception.class})"
@@ -145,12 +145,10 @@ module Rialto
                         "#{exception.message} (#{exception.class})"
         end
 
-        def perform_extract(row)
+        def perform_extract(sunetid)
           results = []
-          if (sunetid = row[:sunetid])
-            Rialto::Etl::Extractors::Sera.new(sunetid: sunetid).each do |result|
-              results << result
-            end
+          Rialto::Etl::Extractors::Sera.new(sunetid: sunetid).each do |result|
+            results << result
           end
           results
         end

--- a/spec/cli/grants_spec.rb
+++ b/spec/cli/grants_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe Rialto::Etl::CLI::Grants do
     }
   end
 
+  let(:empty_sunet_row) do
+    {
+      sunetid: '',
+      first_name: 'Empty',
+      last_name: 'Sunet',
+      uri: 'http://example.com/record2',
+      profileid: '321'
+    }
+  end
+
   describe '#load' do
     context 'with a valid transformer' do
       let(:args) do
@@ -179,6 +189,23 @@ RSpec.describe Rialto::Etl::CLI::Grants do
         expect(loader.send(:extract, row, '1234', true)).to eq(ndj_file)
         expect(Rialto::Etl::Extractors::Sera).to have_received(:new)
           .with(sunetid: 'vjarrett')
+        expect(File).not_to exist(ndj_file)
+      end
+    end
+
+    context 'when the sunetid is blank' do
+      let(:args) do
+        ['--input-file', 'data/researchers.csv', '--output-directory', dir, '--input-directory', dir]
+      end
+
+      before do
+        allow(Rialto::Etl::Extractors::Sera).to receive(:new).and_return([])
+      end
+
+      it 'does not create the ndj file' do
+        ndj_file = File.join(dir, 'sera-321.ndj')
+        expect(loader.send(:extract, empty_sunet_row, '321', true)).to eq(ndj_file)
+        expect(Rialto::Etl::Extractors::Sera).not_to have_received(:new)
         expect(File).not_to exist(ndj_file)
       end
     end


### PR DESCRIPTION
Currently we query SERA against bank SUNETIDs, which is quite slow.

Note: There are currently 14044 blank SUNETids in our researchers.csv data. Assuming ~12 seconds per SERA API call, these blank SUNETs represet just under 2 full days of querying.