### PR TITLE
Allow the load command to be called with a directory as the file argument

### DIFF
--- a/lib/rialto/etl/cli/load.rb
+++ b/lib/rialto/etl/cli/load.rb
@@ -19,7 +19,12 @@ module Rialto
         desc 'call NAME', "Call named loader (`#{@package_name} list` to see available names)"
         # Call a loader by name
         def call(name)
-          Rialto::Etl::Loaders.const_get(name).new(input: options[:input_file]).load
+          return Rialto::Etl::Loaders.const_get(name).new(input: options[:input_file]).load if File.file?(options[:input_file])
+
+          Dir["#{options[:input_file]}/*"].each do |file|
+            next if File.directory? file
+            Rialto::Etl::Loaders.const_get(name).new(input: file).load
+          end
         end
 
         desc 'list', 'List callable loaders'

--- a/lib/rialto/etl/cli/load.rb
+++ b/lib/rialto/etl/cli/load.rb
@@ -21,7 +21,8 @@ module Rialto
         def call(name)
           Dir["#{options[:input_file]}/*"].each do |file|
             next if File.directory? file
-            return Rialto::Etl::Loaders.const_get(name).new(input: file).load
+            say "Loading sparql file: #{file}"
+            Rialto::Etl::Loaders.const_get(name).new(input: file).load
           end
 
           Rialto::Etl::Loaders.const_get(name).new(input: options[:input_file]).load

--- a/lib/rialto/etl/cli/load.rb
+++ b/lib/rialto/etl/cli/load.rb
@@ -19,12 +19,12 @@ module Rialto
         desc 'call NAME', "Call named loader (`#{@package_name} list` to see available names)"
         # Call a loader by name
         def call(name)
-          return Rialto::Etl::Loaders.const_get(name).new(input: options[:input_file]).load if File.file?(options[:input_file])
-
           Dir["#{options[:input_file]}/*"].each do |file|
             next if File.directory? file
-            Rialto::Etl::Loaders.const_get(name).new(input: file).load
+            return Rialto::Etl::Loaders.const_get(name).new(input: file).load
           end
+
+          Rialto::Etl::Loaders.const_get(name).new(input: options[:input_file]).load
         end
 
         desc 'list', 'List callable loaders'


### PR DESCRIPTION
If the input file parameter to the sparql loader is a directory, run the loader for each file in the directory. This allows a load to be called on a directory full of sparql files, like when skipping load for grants.