### PR TITLE
Unping capistrano to avoid deployment issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,8 @@ group :development, :test do
 end
 
 group :development do
-  gem 'capistrano-bundler', '~> 1.4'
-  gem 'dlss-capistrano', '~> 3.4'
+  gem 'capistrano-bundler'
+  gem 'dlss-capistrano'
 end
 
 # These dependencies are excluded on Travis-CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,9 +278,9 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.2)
-  capistrano-bundler (~> 1.4)
+  capistrano-bundler
   config
-  dlss-capistrano (~> 3.4)
+  dlss-capistrano
   faraday (~> 0.15.0)
   faraday_middleware
   honeybadger (~> 4.1)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# config valid for current version and patch releases of Capistrano
-lock '~> 3.11.0'
-
 set :application, 'rialto-etl'
 set :repo_url, 'https://github.com/sul-dlss/rialto-etl.git'
 


### PR DESCRIPTION
This locking is causing deployment to be stopped. By removing the lock and pin I was able to successfully deploy to stage without issue.

We don't seem to do this locking elsewhere, so I think it's safe to remove.