### PR TITLE
Add a specific role for setting the cron jobs

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,8 @@ append :linked_dirs, 'data', 'config/settings'
 # Uncomment the following to require manually verifying the host key before first deploy.
 # set :ssh_options, verify_host_key: :secure
 
-set :whenever_roles, [:app]
+# NOTE: Commented out to prevent crontab updates. Default whenever roles are `[:db]` which we do not use for rialto-etl.
+# set :whenever_roles, [:app]
 
 # update shared_configs
 before 'bundler:install', 'shared_configs:update'

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -2,6 +2,3 @@
 
 server 'rialto-etl-stage.stanford.edu', user: 'rialto', roles: %w[app]
 Capistrano::OneTimeKey.generate_one_time_key!
-
-# Don't run whenever on stage
-Rake::Task['whenever:update_crontab'].clear_actions


### PR DESCRIPTION
## Why was this change made?

We are decommissioning the AWS infrastructure and need to avoid running crons against those assets.

## How was this change tested?

Verified by:

- Clearning the existing cron from the shell: `bundle exec whenever --clear-crontab rialto-etl --set environment=prod --roles=app`
- Deployed against this target branch
- Verified the crons were not reinstalled.


## Which documentation and/or configurations were updated?

N/A


